### PR TITLE
Issue #5543 (nation happiness from misc_mission)

### DIFF
--- a/src/client/cgame/campaign/cp_campaign.h
+++ b/src/client/cgame/campaign/cp_campaign.h
@@ -87,11 +87,18 @@ struct campaign_s;
 #define RASTER 2
 
 /* nation happiness constants */
+/** @todo should happiness constants become scriptable values? */
 #define HAPPINESS_SUBVERSION_LOSS			-0.15
 #define HAPPINESS_ALIEN_MISSION_LOSS		-0.02
 #define HAPPINESS_UFO_SALE_GAIN				0.02
 #define HAPPINESS_UFO_SALE_LOSS				0.005
 #define HAPPINESS_MAX_MISSION_IMPACT		0.07
+#define HAPPINESS_MISSION_GOAL_GAIN			2.0
+#define HAPPINESS_INFECTED_HUMANS			-0.05
+#define HAPPINESS_DELTA_CIVILIAN			0.004
+#define HAPPINESS_DELTA_ALIEN				0.004
+#define HAPPINESS_DIVISOR					5
+
 
 /* Maximum alien groups per alien team category */
 #define MAX_ALIEN_GROUP_PER_CATEGORY	8
@@ -303,6 +310,8 @@ typedef struct missionResults_s {
 	int civiliansKilled;
 	int civiliansKilledFriendlyFire;
 	int civiliansSurvived;
+	float goalAccomplished;	/**< How much % of the main goal of the mission was accomplished (secure panic room...) */
+	int infectedHumans;		/**< Amount of civilians and soldiers infected by XVI */
 } missionResults_t;
 
 /** salary values for a campaign */


### PR DESCRIPTION
* Should fix Issue #5543 (nation happiness from misc_mission, like in mansion map)

* Performance for missions is now composed of 4 factors, instead of just 2; added factors for MissionGoal and InfectedHumans (just basic implementation yet).
* Added 2 new fields to missionResults_t (float goalAccomplished, int infectedHumans), to prepare for new score calculations in future updates.
* Performance from killed aliens is now always zero or positive (small value), so the player will not get a negative score when completing missions different than simple xenocide; this was the main reason for the issue #5543, a negative value from not killed aliens a lot higher than the positive score from saved civilians.
* Moved all used constant values into the .h header file to gather all them, easing if they ever become scriptable.

Signed-off-by: Namerutan <namerutan@hotmail.com>