### PR TITLE
* fix UI soldier skill panel position in recrut soldiew window

### DIFF
--- a/base/ufos/ui/_assets.ufo
+++ b/base/ufos/ui/_assets.ufo
@@ -592,7 +592,7 @@ do
 	local abilities = ufox.build_component({
 		name = "skillbars",
 		class = "panel",
-		pos = {740, 100},
+		pos = {740, 220},
 		size = {250, 120},
 		ghost = true,
 


### PR DESCRIPTION
Fix wrong Y position for Soldiers skills info panel.
Bug:
![Bug](https://image.prntscr.com/image/1cb39b5aa5684076980854c2c8cd6a32.png "Bug")
Fixed:
![Fixed](https://image.prntscr.com/image/6dfce0c5e76d48aa8f6244b95c45955e.png "Fixed")