### PR TITLE
2 bugfixes on the ufo2map tool

### DIFF
--- a/src/tools/ufo2map/ufo2map.cpp
+++ b/src/tools/ufo2map/ufo2map.cpp
@@ -311,6 +311,8 @@ static void U2M_Parameter (int argc, char** argv)
 			config.nocsg = true;
 		} else if (Q_streq(argv[i], "-gamedir")) {
 			Q_strncpyz(config.gamedir, argv[i + 1], sizeof(config.gamedir));
+			// just in case, convert any OS-path seperators to UFO-path separaters
+			FS_NormPath(config.gamedir);
 			Verb_Printf(VERB_LESS, "additional gamedir = %s\n", config.gamedir);
 			i++;
 		} else if (Q_streq(argv[i], "-noshare")) {
@@ -544,6 +546,7 @@ void PrintMapName (void)
 
 int main (int argc, char** argv)
 {
+	char normMapFile[MAX_OSPATH];
 	char bspFilename[MAX_OSPATH];
 	double begin, start, end;
 	long size = 0;
@@ -571,13 +574,36 @@ int main (int argc, char** argv)
 
 	start = time(nullptr);
 
-	Verb_Printf(VERB_NORMAL, "path: '%s'\n", argv[argc - 1]);
+	// copy the map filename
+	Q_strncpyz(normMapFile, argv[argc-1], sizeof(normMapFile));
+	FS_NormPath(normMapFile);
+	Verb_Printf(VERB_NORMAL, "path: '%s'\n", normMapFile);
 
 	FS_InitFilesystem(false);
-	if (config.gamedir[0] != '\0')
+	if (config.gamedir[0] != '\0') {
 		FS_AddGameDirectory(config.gamedir, true);
+	}
+	// get the filename and remove the file extension for further use
+	Com_StripExtension(normMapFile, mapFilename, sizeof(mapFilename));
+	if (config.gamedir[0] != '\0'){
+		/*
+		  in situations were you design a map, you usually want to keep these files outside the main game installation;
+		  so if -gamedir is used and the map-file specified starts with the gamedir, make the mapfile relative to
+		  gamedir so the FS-functions will find it
 
-	Com_StripExtension(argv[argc - 1], mapFilename, sizeof(mapFilename));
+		  Note: we have a case issue here on windows where you can differ in case between the path in --gamedir
+		  and the path to the map-file.
+		*/
+		const char *p = Q_strstart(mapFilename, config.gamedir);
+		if (p != NULL) {
+			// yes, the file specified starts with the gamedir path
+			// drop it so it becomes relative to the gamedir
+			Q_strreplace(mapFilename, config.gamedir, "", mapFilename, sizeof(mapFilename));
+			// Q_strreplace(mapFilename, config.gamedir, "", mapFilenameRel, sizeof(mapFilenameRel));
+			// Q_strncpyz(mapFilename, mapFilenameRel, sizeof(mapFilename));
+		}
+	}
+	// create seperate filenames for the .map and .bsp filess
 	strncpy(baseFilename, mapFilename, sizeof(baseFilename) - 1);
 	strncpy(bspFilename, mapFilename, sizeof(bspFilename) - 1);
 	Com_DefaultExtension(mapFilename, sizeof(mapFilename), ".map");


### PR DESCRIPTION
* fix: -gamedir entry is now converted to ufo-path style separaters
* before storing it in config.gamedir

* fix: if -gamedir is specified, the map specified is checked against
* the value of -gamedir and changed to a relative path before continuing;
* this was because the ufo-filesystem has problems with a full path
* specification of the map on the command line