### PR TITLE
Fix remembering of radar overlay state on geomap

### DIFF
--- a/src/client/cgame/campaign/cp_geoscape.cpp
+++ b/src/client/cgame/campaign/cp_geoscape.cpp
@@ -2262,7 +2262,9 @@ void GEO_SetOverlay (const char* overlayID, int status)
 	}
 	if (Q_streq(overlayID, "radar")) {
 		cgi->Cvar_SetValue("geo_overlay_radar", status);
-		if (GEO_IsRadarOverlayActivated())
+		/* save last decision player took on radar display, in order to be able to restore it later */
+		radarOverlayWasSet = GEO_IsRadarOverlayActivated();
+		if (radarOverlayWasSet)
 			RADAR_UpdateWholeRadarOverlay();
 	}
 }
@@ -2283,10 +2285,6 @@ static void GEO_SetOverlay_f (void)
 	overlay = cgi->Cmd_Argv(1);
 	status = atoi(cgi->Cmd_Argv(2));
 	GEO_SetOverlay(overlay, status);
-
-	/* save last decision player took on radar display, in order to be able to restore it later */
-	if (Q_streq(overlay, "radar"))
-		radarOverlayWasSet = GEO_IsRadarOverlayActivated();
 }
 
 /**


### PR DESCRIPTION
The radar overlay remembering is done on the wrong level:
the `GEO_SetOverlay_f()` console command instead of the
underlying `GEO_SetOverlay()`. Move this handling therein.

To reproduce: in a campaign game, on geoscape, toggle the
radar overlay view on, then click on the globe, or select a base
and exit back to geoscape to find that the radar overlay has
been disabled back instead of being properly remembered.